### PR TITLE
Add basic HTTP server with /ping endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ go.work.sum
 
 # env file
 .env
+
+# Python environment
+.venv

--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-# go-secure-cipher-service
+# Go Encryption Service
+
+This project is a miniature HTTP web service that serves as an encryption engine. It allows users to encrypt strings over the internet using a secret key known only to the server. It also provides a way to decrypt secret messages, but only for authenticated users.
+
+## Features (Planned)
+
+- Encryption endpoint: Accepts a string and returns an encrypted version.
+- Decryption endpoint: Accepts an encrypted string and returns the decrypted version (authenticated users only).
+- Simple ping endpoint for service health checks.
+
+## API Endpoints
+
+1. `/ping`: Responds with a 200 status code to indicate the service is running.
+2. `/encrypt`: Accepts a GET request with a JSON payload containing a message to encrypt.
+3. `/decrypt`: Accepts a GET request with a JSON payload containing a message to decrypt (requires authentication).
+
+## Technical Stack
+
+- Language: Go
+- Web Framework: Net/HTTP (standard library)
+- Deployment: Docker (planned)
+
+## Getting Started
+
+### Prerequisites
+
+- Go 1.16 or later
+- Git
+
+### Installation
+
+1. Clone the repository:
+   ```
+   git clone https://github.com/yourusername/go-encryption-service.git
+   ```
+2. Navigate to the project directory:
+   ```
+   cd go-encryption-service
+   ```
+3. Run the server:
+   ```
+   go run main.go
+   ```
+
+The server will start on port 9090.
+
+## Usage
+
+(To be added as endpoints are implemented)
+
+## Contributing
+
+This project is currently in development. Contributions, ideas, and feedback are welcome.

--- a/local_test/requirements.txt
+++ b/local_test/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/local_test/test_endpoints.py
+++ b/local_test/test_endpoints.py
@@ -1,0 +1,10 @@
+import requests
+
+def test_ping():
+    response = requests.get('http://localhost:8080/ping')
+    print(f"Ping response (Status {response.status_code}):", response.text)
+
+if __name__ == "__main__":
+    print("Testing /ping endpoint...")
+    test_ping()
+    print("Testing complete.")

--- a/main.go
+++ b/main.go
@@ -1,7 +1,15 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 func main() {
-	fmt.Println("Hello, Encryption Service!")
+	http.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "pong")
+	})
+
+	fmt.Println("Server starting on :8080")
+	http.ListenAndServe(":8080", nil)
 }


### PR DESCRIPTION
## Description
This pull request introduces a basic HTTP server implementation with a /ping endpoint. This serves as the foundation for the encryption service.

## Changes
- Updated README.md
- Implemented a basic HTTP server that listens on port 8080
- Added a /ping endpoint that responds with "pong"
- Created a Python script (test_endpoints.py) to test the /ping endpoint

## How to Test
1. Run the server:
```
go run main.go
```
2. In another terminal, run the Python test script:
```
python test_endpoints.py
```
Expected output:
```
Testing /ping endpoint...
Ping response (Status 200): pong
Testing complete.
```